### PR TITLE
Change dot colours

### DIFF
--- a/app/styles/components/previous-line.styl
+++ b/app/styles/components/previous-line.styl
@@ -1,7 +1,8 @@
 .previous-line
 
     > .point
-        fill: #5DFC0A
-        stroke: #3F6826
+        fill: #413D3D
+        stroke: #040004
         stroke-width: 3px
-        opacity: 0.4
+        opacity: .6
+


### PR DESCRIPTION
Please make the green retirement dots black dots, as discussed last week. One of us will then need to find a page with some black dots and get a screen shot as an example. The tutorial text can read:

'When you see black dots surrounding a line of text it means that this line has been transcribed and we no longer need anyone to work on it. Please find other lines for transcription.' 