### PR TITLE
Fix IE11 Promise Polyfill and Flexbox issues

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,6 +13,7 @@
     <body>
         <div ui-view></div>
         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+        <script src="https://cdn.polyfill.io/v2/polyfill.js?unknown=polyfill&features=default,es6,Promise&flags=gated"></script>
         <script src="js/main.js"></script>
 
         <!-- @@analytics -->

--- a/app/styles/components/body.styl
+++ b/app/styles/components/body.styl
@@ -1,0 +1,4 @@
+body
+  > div.ng-scope
+    display: flex
+    flex-direction: column

--- a/app/styles/components/layout-container.styl
+++ b/app/styles/components/layout-container.styl
@@ -6,5 +6,5 @@
 
     > .main
         display: flex
-        flex: 1
+        flex: 1 0 auto
         flex-direction: column


### PR DESCRIPTION
- The webpage can now be viewed properly in IE11. Previous error: 'Promise is Undefined' is solved by adding a polyfill.
- Some layout issues on IE11 were also fixed by adding some flexbox solutions. Without the fix, the classification interface would collapse, so the footer and header would touch.

This is a sister PR to zooniverse/shakespeares_world#304 and... strangely enough... has traces of some IE11 fixes from zooniverse/shakespeares_world#160

I _strongly suspect_ another PR will be needed, since Shakespeare's World PR #160 had changes like...

```
- rotateContainer = svgElement.find('.rotate-container')[0];
+ rotateContainer = document.querySelector('.rotate-container');
```

...to handle the difference in the "find a sub-element" functions for HTML nodes vs SVG elements, on the classifications interface. Unfortunately, I was unable to confirm the classifications interface for Annotate needs further fixes, since there's no data on staging for me test it with.

@simoneduca, this is ready for review. Thoughts on how to get data for the classifications interface test would also be appreciated.
