### PR TITLE
Remove replace flag

### DIFF
--- a/app/modules/transcribe/annotations/image.directive.js
+++ b/app/modules/transcribe/annotations/image.directive.js
@@ -10,7 +10,6 @@ require('./annotations.module.js')
 function imageAnnotation($rootScope, AnnotationsFactory) {
     var directive = {
         link: imageAnnotationLink,
-        replace: true,
         restrict: 'A',
         scope: {
             data: '='


### PR DESCRIPTION
Resolve a long standing issue where image annotations disappeared instantly after drawing them.

Test on https://preview.zooniverse.org/annotate/#!/