### PR TITLE
Remove extra trailing slash from URLs

### DIFF
--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -16,11 +16,10 @@ gulp.task('s3Paths', function () {
 
         gulp.src(filename)
 
-            .pipe(replace(/[ ](href|src)="(?!http)/g, ' $1="' + baseUrl + '/'))
-            .pipe(replace(/(url\(")/g, ' $1' + baseUrl))
-
             // Base tag, needed for ui-router
             .pipe(replace('<base href="/">', '<base href="' + baseUrl + '">'))
+            .pipe(replace(/[ ](href|src)="(?!http)/g, ' $1="' + baseUrl))
+            .pipe(replace(/(url\(")/g, ' $1' + baseUrl))
 
             .pipe(gulp.dest(dest))
                 .on('end', deferred.resolve)


### PR DESCRIPTION
Remove an extra trailing slash from CSS and JS file paths in index.html.

Fixes #229.