### PR TITLE
Fix missing static images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,13 +17,13 @@ node {
   stage('Deploy') {
     if (BRANCH_NAME == 'staging') {
       newImage.inside {
-        sh 'export BUCKET="zooniverse-static"; export PREFIX="preview.zooniverse.org/annotate/"; export BASE_URL="https://preview.zooniverse.org/annotate"; npm run build && npm run deploy'
+        sh 'export BUCKET="zooniverse-static"; export PREFIX="preview.zooniverse.org/annotate/"; export BASE_URL="https://preview.zooniverse.org/annotate/"; npm run build && npm run deploy'
       }
     }
 
     if (BRANCH_NAME == 'master') {
       newImage.inside {
-        sh 'export BUCKET="zooniverse-static"; export PREFIX="anno.tate.org.uk/"; export BASE_URL="https://anno.tate.org.uk"; npm run build && npm run deploy'
+        sh 'export BUCKET="zooniverse-static"; export PREFIX="anno.tate.org.uk/"; export BASE_URL="https://anno.tate.org.uk/"; npm run build && npm run deploy'
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To deploy from your local machine, you'll need to set the `BUCKET`, `PREFIX`  an
 ```sh
 export BUCKET="zooniverse-static"
 export PREFIX="anno.tate.org.uk/"
-export BASE_URL="https://anno.tate.org.uk"
+export BASE_URL="https://anno.tate.org.uk/"
 npm run build && npm run deploy
 ```
 

--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -18,8 +18,6 @@ gulp.task('s3Paths', function () {
 
             // Base tag, needed for ui-router
             .pipe(replace('<base href="/">', '<base href="' + baseUrl + '">'))
-            .pipe(replace(/[ ](href|src)="(?!http)/g, ' $1="' + baseUrl))
-            .pipe(replace(/(url\(")/g, ' $1' + baseUrl))
 
             .pipe(gulp.dest(dest))
                 .on('end', deferred.resolve)

--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -18,6 +18,9 @@ gulp.task('s3Paths', function () {
 
             // Base tag, needed for ui-router
             .pipe(replace('<base href="/">', '<base href="' + baseUrl + '">'))
+            // Search for URLs that begin with / and rewrite them as fully-qualified URLs.
+            // This allows the browser to resolve linked files correctly on
+            // preview.zooniverse.org/annotate/ and on anno.tate.org.uk/
             .pipe(replace(/[ ](href|src)="\//g, ' $1="' + baseUrl))
             .pipe(replace(/(url\(")\//g, ' $1' + baseUrl))
 

--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -18,6 +18,8 @@ gulp.task('s3Paths', function () {
 
             // Base tag, needed for ui-router
             .pipe(replace('<base href="/">', '<base href="' + baseUrl + '">'))
+            .pipe(replace(/[ ](href|src)="\//g, ' $1="' + baseUrl + '/'))
+            .pipe(replace(/(url\(")\//g, ' $1' + baseUrl + '/'))
 
             .pipe(gulp.dest(dest))
                 .on('end', deferred.resolve)

--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -13,6 +13,8 @@ gulp.task('s3Paths', function () {
         var deferred = Q.defer();
         var baseUrl = process.env.BASE_URL;
         var dest = filename.substring(0, filename.lastIndexOf('/'));
+        var lastChar = baseUrl.slice(-1);
+        baseUrl = lastChar === '/' ? baseUrl : baseUrl + '/';
 
         gulp.src(filename)
 

--- a/gulp/tasks/s3-paths.js
+++ b/gulp/tasks/s3-paths.js
@@ -18,8 +18,8 @@ gulp.task('s3Paths', function () {
 
             // Base tag, needed for ui-router
             .pipe(replace('<base href="/">', '<base href="' + baseUrl + '">'))
-            .pipe(replace(/[ ](href|src)="\//g, ' $1="' + baseUrl + '/'))
-            .pipe(replace(/(url\(")\//g, ' $1' + baseUrl + '/'))
+            .pipe(replace(/[ ](href|src)="\//g, ' $1="' + baseUrl))
+            .pipe(replace(/(url\(")\//g, ' $1' + baseUrl))
 
             .pipe(gulp.dest(dest))
                 .on('end', deferred.resolve)


### PR DESCRIPTION
Let the browser use the `<base>` tag to resolve relative URLs for images, scripts and stylesheets.

URLs relative to / still need to be hacked with a regex in order to work from a subdirectory of the site root like `preview.zooniverse.org/annotate/`

Fixes #231.
Follows on from #230, which fixed a bug where the site did not load at all in production.